### PR TITLE
dfu.js: send SET_INTERFACE request for alternate 0

### DIFF
--- a/dfu-util/dfu.js
+++ b/dfu-util/dfu.js
@@ -109,8 +109,18 @@ var dfu = {};
         const altSetting = this.settings.alternate.alternateSetting;
         let intf = this.device_.configuration.interfaces[intfNumber];
         if (intf.alternate === null ||
-            intf.alternate.alternateSetting != altSetting) {
-            await this.device_.selectAlternateInterface(intfNumber, altSetting);
+            intf.alternate.alternateSetting != altSetting ||
+            intf.alternates.length > 1) {
+            try {
+                await this.device_.selectAlternateInterface(intfNumber, altSetting);
+            } catch (error) {
+                if (intf.alternate.alternateSetting == altSetting &&
+                    error.endsWith("Unable to set device interface.")) {
+                    this.logWarning(`Redundant SET_INTERFACE request to select altSetting ${altSetting} failed`);
+                } else {
+                    throw error;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This pull request attempts to resolve #14.

If there are multiple alternate settings, select the alternate interface even if it's already selected. This typically is only relevant when there are multiple alternate settings and alternate 0 needs to be selected explicitly.

For testing purposes, a live copy can be accessed here:
https://ternus.connifer.com/dfu-util/